### PR TITLE
Remove dependency on the reflect package

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -599,12 +599,11 @@ func (mysql *MySQL) getResult() (err os.Error) {
 			mysql.error(CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR)
 		} else {
 			mysql.error(int(pkt.errno), pkt.error)
+			err = os.NewError(fmt.Sprintf("[seq %d] [errno %d] %s", int(mysql.sequence), int(pkt.errno), pkt.error))
 		}
 		if mysql.Logging {
 			log.Print("[" + fmt.Sprint(mysql.sequence) + "] Received error packet from server")
 		}
-		// Return error response
-		err = os.NewError("An error was received from MySQL")
 	// Result Set Packet 1-250 (first byte of Length-Coded Binary)
 	case c >= 0x01 && c <= 0xfa && mysql.curRes == nil:
 		pkt := new(packetResultSet)

--- a/mysql.go
+++ b/mysql.go
@@ -12,7 +12,6 @@ import (
 	"bufio"
 	"os"
 	"log"
-	"reflect"
 	"sync"
 )
 
@@ -403,11 +402,9 @@ func (mysql *MySQL) parseParams(p []interface{}) {
 	}
 	// Reflect 5th param to determine if it is port or socket
 	if len(p) > 4 {
-		v := reflect.NewValue(p[4])
-		if v.Type().Name() == "int" {
-			mysql.auth.port = v.Interface().(int)
-		} else if v.Type().Name() == "string" {
-			mysql.auth.socket = v.Interface().(string)
+		switch v := p[4].(type) {
+			case int: mysql.auth.port = v
+			case string: mysql.auth.socket = v
 		}
 	}
 	return

--- a/mysql_statement.go
+++ b/mysql_statement.go
@@ -358,12 +358,11 @@ func (stmt *MySQLStatement) getPrepareResult() (err os.Error) {
 			stmt.error(CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR)
 		} else {
 			stmt.error(int(pkt.errno), pkt.error)
+			err = os.NewError(fmt.Sprintf("[seq %d] [errno %d] %s", int(mysql.sequence), int(pkt.errno), pkt.error))
 		}
 		if mysql.Logging {
 			log.Print("[" + fmt.Sprint(mysql.sequence) + "] Received error packet from server")
 		}
-		// Return error response
-		err = os.NewError("An error was received from MySQL")
 	// Making assumption that statement packets follow similar format to result packets
 	// If param count > 0 then first will get parameter packets following EOF
 	// After this should get standard field packets followed by EOF
@@ -498,12 +497,11 @@ func (stmt *MySQLStatement) getExecuteResult() (err os.Error) {
 			stmt.error(CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR)
 		} else {
 			stmt.error(int(pkt.errno), pkt.error)
+			err = os.NewError(fmt.Sprintf("[seq %d] [errno %d] %s", int(mysql.sequence), pkt.errno, pkt.error))
 		}
 		if mysql.Logging {
 			log.Print("[" + fmt.Sprint(mysql.sequence) + "] Received error packet from server")
 		}
-		// Return error response
-		err = os.NewError("An error was received from MySQL")
 	// Result Set Packet 1-250 (first byte of Length-Coded Binary)
 	case c >= 0x01 && c <= 0xfa && !stmt.resExecuted:
 		pkt := new(packetResultSet)


### PR DESCRIPTION
Hi,

Just a small patch to remove a dependency on Go's reflect package. A lot of the funky reflection techniques you're using for type checks at the moment are actually supported in the core language (namely type switches).

Small potential performance increase, and makes the code dealing with types a little nicer too.

Cheers,
Tom
