### PR TITLE
Improved error messages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-GoMySQL Version 0.2.2
+GoMySQL Version 0.2.3
 =====================
 
 
@@ -7,6 +7,7 @@ Revision History
 
 0.2.x series [current]
 
+* 0.2.3 - Merged code improvements by Thomas Lee (https://github.com/thomaslee/GoMySQL/commit/838eced14f4ef645407fb5b482b26b88822407a2)
 * 0.2.2 - Resolves issue #16.
 * 0.2.1 - Updated to work with latest release of Go plus 1 or 2 minor tweaks.
 * 0.2.0 - Functions have been reworked and now always return os.Error to provide a generic and consistant design. Improved logging output. Improved client stability. Removed length vs buffered length checks as they don't work with packets > 4096 bytes. Added new Escape function, although this is currently only suitiable for short strings. Tested library with much larger databases such as multi-gigabyte tables and multi-megabyte blogs. Many minor bug fixes. Resolved issue #3, #4 and #5.

--- a/mysql.go
+++ b/mysql.go
@@ -597,14 +597,14 @@ func (mysql *MySQL) getResult() (err os.Error) {
 		err = pkt.read(mysql.reader)
 		if err != nil {
 			mysql.error(CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR)
+			err = os.NewError(fmt.Sprintf("[%d] %s", CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR))
 		} else {
 			mysql.error(int(pkt.errno), pkt.error)
+			err = os.NewError(fmt.Sprintf("[%d] %s", pkt.errno, pkt.error))
 		}
 		if mysql.Logging {
 			log.Print("[" + fmt.Sprint(mysql.sequence) + "] Received error packet from server")
 		}
-		// Return error response
-		err = os.NewError("An error was received from MySQL")
 	// Result Set Packet 1-250 (first byte of Length-Coded Binary)
 	case c >= 0x01 && c <= 0xfa && mysql.curRes == nil:
 		pkt := new(packetResultSet)

--- a/mysql.go
+++ b/mysql.go
@@ -12,7 +12,6 @@ import (
 	"bufio"
 	"os"
 	"log"
-	"reflect"
 	"sync"
 )
 
@@ -403,11 +402,9 @@ func (mysql *MySQL) parseParams(p []interface{}) {
 	}
 	// Reflect 5th param to determine if it is port or socket
 	if len(p) > 4 {
-		v := reflect.NewValue(p[4])
-		if v.Type().Name() == "int" {
-			mysql.auth.port = v.Interface().(int)
-		} else if v.Type().Name() == "string" {
-			mysql.auth.socket = v.Interface().(string)
+		switch v := p[4].(type) {
+			case int: mysql.auth.port = v
+			case string: mysql.auth.socket = v
 		}
 	}
 	return

--- a/mysql.go
+++ b/mysql.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	Version       = "0.2.2"
+	Version       = "0.2.3"
 	DefaultPort   = 3306
 	DefaultSock   = "/var/run/mysqld/mysqld.sock"
 	MaxPacketSize = 1 << 24

--- a/mysql_statement.go
+++ b/mysql_statement.go
@@ -356,14 +356,14 @@ func (stmt *MySQLStatement) getPrepareResult() (err os.Error) {
 		err = pkt.read(mysql.reader)
 		if err != nil {
 			stmt.error(CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR)
+			err = os.NewError(fmt.Sprintf("[%d] %s", CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR))
 		} else {
 			stmt.error(int(pkt.errno), pkt.error)
+			err = os.NewError(fmt.Sprintf("[%d] %s", pkt.errno, pkt.error))
 		}
 		if mysql.Logging {
 			log.Print("[" + fmt.Sprint(mysql.sequence) + "] Received error packet from server")
 		}
-		// Return error response
-		err = os.NewError("An error was received from MySQL")
 	// Making assumption that statement packets follow similar format to result packets
 	// If param count > 0 then first will get parameter packets following EOF
 	// After this should get standard field packets followed by EOF
@@ -496,14 +496,14 @@ func (stmt *MySQLStatement) getExecuteResult() (err os.Error) {
 		err = pkt.read(mysql.reader)
 		if err != nil {
 			stmt.error(CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR)
+			err = os.NewError(fmt.Sprintf("[%d] %s", CR_MALFORMED_PACKET, CR_MALFORMED_PACKET_STR))
 		} else {
 			stmt.error(int(pkt.errno), pkt.error)
+			err = os.NewError(fmt.Sprintf("[%d] %s", pkt.errno, pkt.error))
 		}
 		if mysql.Logging {
 			log.Print("[" + fmt.Sprint(mysql.sequence) + "] Received error packet from server")
 		}
-		// Return error response
-		err = os.NewError("An error was received from MySQL")
 	// Result Set Packet 1-250 (first byte of Length-Coded Binary)
 	case c >= 0x01 && c <= 0xfa && !stmt.resExecuted:
 		pkt := new(packetResultSet)


### PR DESCRIPTION
Hi Phil,

Changes to the error messages reported in os.Errors when MySQL reports an error. Changes to the ones I accidentally checked in to the last pull request.

Not sure if you're particularly keen to incorporate these, but it's here all the same. One can always just like at mysql.Errno / mysql.Error, but I tend to rely on the messages in the os.Error myself.

Cheers,
Tom
