### PR TITLE
Make Client.conn an io.ReadWriteCloser

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -8,6 +8,7 @@ package mysql
 // Imports
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"net"
@@ -57,7 +58,7 @@ type Client struct {
 	dbname  string
 
 	// Connection
-	conn      net.Conn
+	conn      io.ReadWriteCloser
 	r         *reader
 	w         *writer
 	connected bool

--- a/reader.go
+++ b/reader.go
@@ -7,18 +7,17 @@ package mysql
 
 import (
 	"io"
-	"net"
 	"os"
 )
 
 // Packet reader struct
 type reader struct {
-	conn     net.Conn
+	conn     io.ReadWriteCloser
 	protocol uint8
 }
 
 // Create a new reader
-func newReader(conn net.Conn) *reader {
+func newReader(conn io.ReadWriteCloser) *reader {
 	return &reader{
 		conn:     conn,
 		protocol: DEFAULT_PROTOCOL,

--- a/writer.go
+++ b/writer.go
@@ -6,17 +6,17 @@
 package mysql
 
 import (
-	"net"
+	"io"
 	"os"
 )
 
 // Packet writer struct
 type writer struct {
-	conn net.Conn
+	conn io.ReadWriteCloser
 }
 
 // Create a new reader
-func newWriter(conn net.Conn) *writer {
+func newWriter(conn io.ReadWriteCloser) *writer {
 	return &writer{
 		conn: conn,
 	}


### PR DESCRIPTION
I have a commit that's close to ready with a dummy server implementation. This change makes that server simpler because it doesn't have to stub out as many methods. We're not using any of net.Conn's other methods anyway.
