### PR TITLE
Getting errors from FetchRow/Map

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -6,8 +6,8 @@
 package mysql
 
 import (
+	"io"
 	"math"
-	"os"
 	"strconv"
 )
 
@@ -121,6 +121,7 @@ func ui32tob(n uint32) (b []byte) {
 	}
 	return
 }
+
 // bytes to int64
 func btoi64(b []byte) int64 {
 	return int64(btoui64(b))
@@ -169,7 +170,7 @@ func f64tob(f float64) []byte {
 }
 
 // bytes to length
-func btolcb(b []byte) (num uint64, n int, err os.Error) {
+func btolcb(b []byte) (num uint64, n int, err error) {
 	switch {
 	// 0-250 = value of first byte
 	case b[0] <= 250:
@@ -193,7 +194,7 @@ func btolcb(b []byte) (num uint64, n int, err os.Error) {
 	}
 	// Check there are enough bytes
 	if len(b) < n {
-		err = os.EOF
+		err = io.EOF
 		return
 	}
 	// Get uint64
@@ -229,7 +230,7 @@ func atoui64(i interface{}) (n uint64) {
 		return t
 	case string:
 		// Convert to int64 first for signing bit
-		in, err := strconv.Atoi64(t)
+		in, err := strconv.ParseInt(t, 10, 64)
 		if err != nil {
 			panic("Invalid string for integer conversion")
 		}
@@ -248,8 +249,8 @@ func atof64(i interface{}) (f float64) {
 	case float64:
 		return t
 	case string:
-		var err os.Error
-		f, err = strconv.Atof64(t)
+		var err error
+		f, err = strconv.ParseFloat(t, 64)
 		if err != nil {
 			panic("Invalid string for floating point conversion")
 		}
@@ -263,13 +264,13 @@ func atof64(i interface{}) (f float64) {
 func atos(i interface{}) (s string) {
 	switch t := i.(type) {
 	case int64:
-		s = strconv.Itoa64(t)
+		s = strconv.FormatInt(t, 10)
 	case uint64:
-		s = strconv.Uitoa64(t)
+		s = strconv.FormatUint(t, 10)
 	case float32:
-		s = strconv.Ftoa32(t, 'f', -1)
+		s = strconv.FormatFloat(float64(t), 'f', -1, 32)
 	case float64:
-		s = strconv.Ftoa64(t, 'f', -1)
+		s = strconv.FormatFloat(t, 'f', -1, 64)
 	case []byte:
 		s = string(t)
 	case Date:

--- a/error.go
+++ b/error.go
@@ -9,127 +9,127 @@ import "fmt"
 
 // Client error types
 type Errno int
-type Error string
+type Errstr string
 
 const (
 	CR_UNKNOWN_ERROR               Errno = 2000
-	CR_UNKNOWN_ERROR_STR           Error = "Unknown MySQL error"
+	CR_UNKNOWN_ERROR_STR           Errstr = "Unknown MySQL error"
 	CR_SOCKET_CREATE_ERROR         Errno = 2001
-	CR_SOCKET_CREATE_ERROR_STR     Error = "Can't create UNIX socket (%d)"
+	CR_SOCKET_CREATE_ERROR_STR     Errstr = "Can't create UNIX socket (%d)"
 	CR_CONNECTION_ERROR            Errno = 2002
-	CR_CONNECTION_ERROR_STR        Error = "Can't connect to local MySQL server through socket '%s'"
+	CR_CONNECTION_ERROR_STR        Errstr = "Can't connect to local MySQL server through socket '%s'"
 	CR_CONN_HOST_ERROR             Errno = 2003
-	CR_CONN_HOST_ERROR_STR         Error = "Can't connect to MySQL server on '%s'"
+	CR_CONN_HOST_ERROR_STR         Errstr = "Can't connect to MySQL server on '%s'"
 	CR_IPSOCK_ERROR                Errno = 2004
-	CR_IPSOCK_ERROR_STR            Error = "Can't create TCP/IP socket (%d)"
+	CR_IPSOCK_ERROR_STR            Errstr = "Can't create TCP/IP socket (%d)"
 	CR_UNKNOWN_HOST                Errno = 2005
-	CR_UNKNOWN_HOST_STR            Error = "Uknown MySQL server host '%s' (%d)"
+	CR_UNKNOWN_HOST_STR            Errstr = "Uknown MySQL server host '%s' (%d)"
 	CR_SERVER_GONE_ERROR           Errno = 2006
-	CR_SERVER_GONE_ERROR_STR       Error = "MySQL server has gone away"
+	CR_SERVER_GONE_ERROR_STR       Errstr = "MySQL server has gone away"
 	CR_VERSION_ERROR               Errno = 2007
-	CR_VERSION_ERROR_STR           Error = "Protocol mismatch; server version = %d, client version = %d"
+	CR_VERSION_ERROR_STR           Errstr = "Protocol mismatch; server version = %d, client version = %d"
 	CR_OUT_OF_MEMORY               Errno = 2008
-	CR_OUT_OF_MEMORY_STR           Error = "MySQL client ran out of memory"
+	CR_OUT_OF_MEMORY_STR           Errstr = "MySQL client ran out of memory"
 	CR_WRONG_HOST_INFO             Errno = 2009
-	CR_WRONG_HOST_INFO_STR         Error = "Wrong host info"
+	CR_WRONG_HOST_INFO_STR         Errstr = "Wrong host info"
 	CR_LOCALHOST_CONNECTION        Errno = 2010
-	CR_LOCALHOST_CONNECTION_STR    Error = "Localhost via UNIX socket"
+	CR_LOCALHOST_CONNECTION_STR    Errstr = "Localhost via UNIX socket"
 	CR_TCP_CONNECTION              Errno = 2011
-	CR_TCP_CONNECTION_STR          Error = "%s via TCP/IP"
+	CR_TCP_CONNECTION_STR          Errstr = "%s via TCP/IP"
 	CR_SERVER_HANDSHAKE_ERR        Errno = 2012
-	CR_SERVER_HANDSHAKE_ERR_STR    Error = "Error in server handshake"
+	CR_SERVER_HANDSHAKE_ERR_STR    Errstr = "Error in server handshake"
 	CR_SERVER_LOST                 Errno = 2013
-	CR_SERVER_LOST_STR             Error = "Lost connection to MySQL server during query"
+	CR_SERVER_LOST_STR             Errstr = "Lost connection to MySQL server during query"
 	CR_COMMANDS_OUT_OF_SYNC        Errno = 2014
-	CR_COMMANDS_OUT_OF_SYNC_STR    Error = "Commands out of sync; you can't run this command now"
+	CR_COMMANDS_OUT_OF_SYNC_STR    Errstr = "Commands out of sync; you can't run this command now"
 	CR_NAMEDPIPE_CONNECTION        Errno = 2015
-	CR_NAMEDPIPE_CONNECTION_STR    Error = "Named pipe: %s"
+	CR_NAMEDPIPE_CONNECTION_STR    Errstr = "Named pipe: %s"
 	CR_NAMEDPIPEWAIT_ERROR         Errno = 2016
-	CR_NAMEDPIPEWAIT_ERROR_STR     Error = "Can't wait for named pipe to host: %s pipe: %s (%lu)"
+	CR_NAMEDPIPEWAIT_ERROR_STR     Errstr = "Can't wait for named pipe to host: %s pipe: %s (%lu)"
 	CR_NAMEDPIPEOPEN_ERROR         Errno = 2017
-	CR_NAMEDPIPEOPEN_ERROR_STR     Error = "Can't open named pipe to host: %s pipe: %s (%lu)"
+	CR_NAMEDPIPEOPEN_ERROR_STR     Errstr = "Can't open named pipe to host: %s pipe: %s (%lu)"
 	CR_NAMEDPIPESETSTATE_ERROR     Errno = 2018
-	CR_NAMEDPIPESETSTATE_ERROR_STR Error = "Can't set state of named pipe to host: %s pipe: %s (%lu)"
+	CR_NAMEDPIPESETSTATE_ERROR_STR Errstr = "Can't set state of named pipe to host: %s pipe: %s (%lu)"
 	CR_CANT_READ_CHARSET           Errno = 2019
-	CR_CANT_READ_CHARSET_STR       Error = "Can't initialize character set %s (path: %s)"
+	CR_CANT_READ_CHARSET_STR       Errstr = "Can't initialize character set %s (path: %s)"
 	CR_NET_PACKET_TOO_LARGE        Errno = 2020
-	CR_NET_PACKET_TOO_LARGE_STR    Error = "Got packet bigger than 'max_allowed_packet' bytes"
+	CR_NET_PACKET_TOO_LARGE_STR    Errstr = "Got packet bigger than 'max_allowed_packet' bytes"
 	CR_EMBEDDED_CONNECTION         Errno = 2021
-	CR_EMBEDDED_CONNECTION_STR     Error = "Embedded server"
+	CR_EMBEDDED_CONNECTION_STR     Errstr = "Embedded server"
 	CR_PROBE_SLAVE_STATUS          Errno = 2022
-	CR_PROBE_SLAVE_STATUS_STR      Error = "Error on SHOW SLAVE STATUS:"
+	CR_PROBE_SLAVE_STATUS_STR      Errstr = "Error on SHOW SLAVE STATUS:"
 	CR_PROBE_SLAVE_HOSTS           Errno = 2023
-	CR_PROBE_SLAVE_HOSTS_STR       Error = "Error on SHOW SLAVE HOSTS:"
+	CR_PROBE_SLAVE_HOSTS_STR       Errstr = "Error on SHOW SLAVE HOSTS:"
 	CR_PROBE_SLAVE_CONNECT         Errno = 2024
-	CR_PROBE_SLAVE_CONNECT_STR     Error = "Error connecting to slave:"
+	CR_PROBE_SLAVE_CONNECT_STR     Errstr = "Error connecting to slave:"
 	CR_PROBE_MASTER_CONNECT        Errno = 2025
-	CR_PROBE_MASTER_CONNECT_STR    Error = "Error connecting to master:"
+	CR_PROBE_MASTER_CONNECT_STR    Errstr = "Error connecting to master:"
 	CR_SSL_CONNECTION_ERROR        Errno = 2026
-	CR_SSL_CONNECTION_ERROR_STR    Error = "SSL connection error"
+	CR_SSL_CONNECTION_ERROR_STR    Errstr = "SSL connection error"
 	CR_MALFORMED_PACKET            Errno = 2027
-	CR_MALFORMED_PACKET_STR        Error = "Malformed Packet"
+	CR_MALFORMED_PACKET_STR        Errstr = "Malformed Packet"
 	CR_WRONG_LICENSE               Errno = 2028
-	CR_WRONG_LICENSE_STR           Error = "This client library is licensed only for use with MySQL servers having '%s' license"
+	CR_WRONG_LICENSE_STR           Errstr = "This client library is licensed only for use with MySQL servers having '%s' license"
 	CR_NULL_POINTER                Errno = 2029
-	CR_NULL_POINTER_STR            Error = "Invalid use of null pointer"
+	CR_NULL_POINTER_STR            Errstr = "Invalid use of null pointer"
 	CR_NO_PREPARE_STMT             Errno = 2030
-	CR_NO_PREPARE_STMT_STR         Error = "Statement not prepared"
+	CR_NO_PREPARE_STMT_STR         Errstr = "Statement not prepared"
 	CR_PARAMS_NOT_BOUND            Errno = 2031
-	CR_PARAMS_NOT_BOUND_STR        Error = "No data supplied for parameters in prepared statement"
+	CR_PARAMS_NOT_BOUND_STR        Errstr = "No data supplied for parameters in prepared statement"
 	CR_DATA_TRUNCATED              Errno = 2032
-	CR_DATA_TRUNCATED_STR          Error = "Data truncated"
+	CR_DATA_TRUNCATED_STR          Errstr = "Data truncated"
 	CR_NO_PARAMETERS_EXISTS        Errno = 2033
-	CR_NO_PARAMETERS_EXISTS_STR    Error = "No parameters exist in the statement"
+	CR_NO_PARAMETERS_EXISTS_STR    Errstr = "No parameters exist in the statement"
 	CR_INVALID_PARAMETER_NO        Errno = 2034
-	CR_INVALID_PARAMETER_NO_STR    Error = "Invalid parameter number"
+	CR_INVALID_PARAMETER_NO_STR    Errstr = "Invalid parameter number"
 	CR_INVALID_BUFFER_USE          Errno = 2035
-	CR_INVALID_BUFFER_USE_STR      Error = "Can't send long data for non-string/non-binary data types (parameter: %d)"
+	CR_INVALID_BUFFER_USE_STR      Errstr = "Can't send long data for non-string/non-binary data types (parameter: %d)"
 	CR_UNSUPPORTED_PARAM_TYPE      Errno = 2036
-	CR_UNSUPPORTED_PARAM_TYPE_STR  Error = "Using unsupported parameter type: %s (parameter: %d)"
+	CR_UNSUPPORTED_PARAM_TYPE_STR  Errstr = "Using unsupported parameter type: %s (parameter: %d)"
 	CR_CONN_UNKNOW_PROTOCOL        Errno = 2047
-	CR_CONN_UNKNOW_PROTOCOL_STR    Error = "Wrong or unknown protocol"
+	CR_CONN_UNKNOW_PROTOCOL_STR    Errstr = "Wrong or unknown protocol"
 	CR_SECURE_AUTH                 Errno = 2049
-	CR_SECURE_AUTH_STR             Error = "Connection using old (pre-4.1.1) authentication protocol refused (client option 'secure_auth' enabled)"
+	CR_SECURE_AUTH_STR             Errstr = "Connection using old (pre-4.1.1) authentication protocol refused (client option 'secure_auth' enabled)"
 	CR_FETCH_CANCELED              Errno = 2050
-	CR_FETCH_CANCELED_STR          Error = "Row retrieval was canceled by mysql_stmt_close() call"
+	CR_FETCH_CANCELED_STR          Errstr = "Row retrieval was canceled by mysql_stmt_close() call"
 	CR_NO_DATA                     Errno = 2051
-	CR_NO_DATA_STR                 Error = "Attempt to read column without prior row fetch"
+	CR_NO_DATA_STR                 Errstr = "Attempt to read column without prior row fetch"
 	CR_NO_STMT_METADATA            Errno = 2052
-	CR_NO_STMT_METADATA_STR        Error = "Prepared statement contains no metadata"
+	CR_NO_STMT_METADATA_STR        Errstr = "Prepared statement contains no metadata"
 	CR_NO_RESULT_SET               Errno = 2053
-	CR_NO_RESULT_SET_STR           Error = "Attempt to read a row while there is no result set associated with the statement"
+	CR_NO_RESULT_SET_STR           Errstr = "Attempt to read a row while there is no result set associated with the statement"
 	CR_NOT_IMPLEMENTED             Errno = 2054
-	CR_NOT_IMPLEMENTED_STR         Error = "This feature is not implemented yet"
+	CR_NOT_IMPLEMENTED_STR         Errstr = "This feature is not implemented yet"
 	CR_SERVER_LOST_EXTENDED        Errno = 2055
-	CR_SERVER_LOST_EXTENDED_STR    Error = "Lost connection to MySQL server at '%s', system error: %d"
+	CR_SERVER_LOST_EXTENDED_STR    Errstr = "Lost connection to MySQL server at '%s', system error: %d"
 	CR_STMT_CLOSED                 Errno = 2056
-	CR_STMT_CLOSED_STR             Error = "Statement closed indirectly because of a preceeding %s() call"
+	CR_STMT_CLOSED_STR             Errstr = "Statement closed indirectly because of a preceeding %s() call"
 	CR_NEW_STMT_METADATA           Errno = 2057
-	CR_NEW_STMT_METADATA_STR       Error = "The number of columns in the result set differs from the number of bound buffers. You must reset the statement, rebind the result set columns, and execute the statement again"
+	CR_NEW_STMT_METADATA_STR       Errstr = "The number of columns in the result set differs from the number of bound buffers. You must reset the statement, rebind the result set columns, and execute the statement again"
 	CR_ALREADY_CONNECTED           Errno = 2058
-	CR_ALREADY_CONNECTED_STR       Error = "This handle is already connected"
+	CR_ALREADY_CONNECTED_STR       Errstr = "This handle is already connected"
 	CR_AUTH_PLUGIN_CANNOT_LOAD     Errno = 2059
-	CR_AUTH_PLUGIN_CANNOT_LOAD_STR Error = "Authentication plugin '%s' cannot be loaded: %s"
+	CR_AUTH_PLUGIN_CANNOT_LOAD_STR Errstr = "Authentication plugin '%s' cannot be loaded: %s"
 )
 
 // Client error struct
 type ClientError struct {
 	Errno Errno
-	Error Error
+	Errstr Errstr
 }
 
 // Convert to string
-func (e *ClientError) String() string {
-	return fmt.Sprintf("#%d %s", e.Errno, e.Error)
+func (e *ClientError) Error() string {
+	return fmt.Sprintf("#%d %s", e.Errno, e.Errstr)
 }
 
 // Server error struct
 type ServerError struct {
 	Errno Errno
-	Error Error
+	Errstr Errstr
 }
 
 // Convert to string
-func (e *ServerError) String() string {
-	return fmt.Sprintf("#%d %s", e.Errno, e.Error)
+func (e *ServerError) Error() string {
+	return fmt.Sprintf("#%d %s", e.Errno, e.Errstr)
 }

--- a/mysql.go
+++ b/mysql.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -100,7 +100,7 @@ func NewClient(protocol ...uint8) (c *Client) {
 }
 
 // Connect to server via TCP
-func DialTCP(raddr, user, passwd string, dbname ...string) (c *Client, err os.Error) {
+func DialTCP(raddr, user, passwd string, dbname ...string) (c *Client, err error) {
 	c = NewClient(DEFAULT_PROTOCOL)
 	// Add port if not set
 	if strings.Index(raddr, ":") == -1 {
@@ -112,7 +112,7 @@ func DialTCP(raddr, user, passwd string, dbname ...string) (c *Client, err os.Er
 }
 
 // Connect to server via unix socket
-func DialUnix(raddr, user, passwd string, dbname ...string) (c *Client, err os.Error) {
+func DialUnix(raddr, user, passwd string, dbname ...string) (c *Client, err error) {
 	c = NewClient(DEFAULT_PROTOCOL)
 	// Use default socket if socket is empty
 	if raddr == "" {
@@ -124,7 +124,7 @@ func DialUnix(raddr, user, passwd string, dbname ...string) (c *Client, err os.E
 }
 
 // Connect to the server
-func (c *Client) Connect(network, raddr, user, passwd string, dbname ...string) (err os.Error) {
+func (c *Client) Connect(network, raddr, user, passwd string, dbname ...string) (err error) {
 	// Log connect
 	c.log(1, "=== Begin connect ===")
 	// Check not already connected
@@ -152,7 +152,7 @@ func (c *Client) Connect(network, raddr, user, passwd string, dbname ...string) 
 }
 
 // Close connection to server
-func (c *Client) Close() (err os.Error) {
+func (c *Client) Close() (err error) {
 	// Log close
 	c.log(1, "=== Begin close ===")
 	// Check connection
@@ -173,7 +173,7 @@ func (c *Client) Close() (err os.Error) {
 }
 
 // Change the current database
-func (c *Client) ChangeDb(dbname string) (err os.Error) {
+func (c *Client) ChangeDb(dbname string) (err error) {
 	// Auto reconnect
 	defer func() {
 		if err != nil && c.checkNet(err) && c.Reconnect {
@@ -205,7 +205,7 @@ func (c *Client) ChangeDb(dbname string) (err os.Error) {
 }
 
 // Send a query/queries to the server
-func (c *Client) Query(sql string) (err os.Error) {
+func (c *Client) Query(sql string) (err error) {
 	// Auto reconnect
 	defer func() {
 		if err != nil && c.checkNet(err) && c.Reconnect {
@@ -242,7 +242,7 @@ func (c *Client) Query(sql string) (err os.Error) {
 }
 
 // Fetch all rows for a result and store it, returning the result set
-func (c *Client) StoreResult() (result *Result, err os.Error) {
+func (c *Client) StoreResult() (result *Result, err error) {
 	// Auto reconnect
 	defer func() {
 		err = c.simpleReconnect(err)
@@ -269,7 +269,7 @@ func (c *Client) StoreResult() (result *Result, err os.Error) {
 }
 
 // Use a result set, does not store rows
-func (c *Client) UseResult() (result *Result, err os.Error) {
+func (c *Client) UseResult() (result *Result, err error) {
 	// Auto reconnect
 	defer func() {
 		err = c.simpleReconnect(err)
@@ -290,7 +290,7 @@ func (c *Client) UseResult() (result *Result, err os.Error) {
 }
 
 // Free the current result
-func (c *Client) FreeResult() (err os.Error) {
+func (c *Client) FreeResult() (err error) {
 	// Auto reconnect
 	defer func() {
 		err = c.simpleReconnect(err)
@@ -329,7 +329,7 @@ func (c *Client) MoreResults() bool {
 }
 
 // Move to the next available result
-func (c *Client) NextResult() (more bool, err os.Error) {
+func (c *Client) NextResult() (more bool, err error) {
 	// Auto reconnect
 	defer func() {
 		err = c.simpleReconnect(err)
@@ -354,7 +354,7 @@ func (c *Client) NextResult() (more bool, err os.Error) {
 }
 
 // Set autocommit
-func (c *Client) SetAutoCommit(state bool) (err os.Error) {
+func (c *Client) SetAutoCommit(state bool) (err error) {
 	// Log set autocommit
 	c.log(1, "=== Begin set autocommit ===")
 	// Use set autocommit query
@@ -368,7 +368,7 @@ func (c *Client) SetAutoCommit(state bool) (err os.Error) {
 }
 
 // Start a transaction
-func (c *Client) Start() (err os.Error) {
+func (c *Client) Start() (err error) {
 	// Log start transaction
 	c.log(1, "=== Begin start transaction ===")
 	// Use start transaction query
@@ -376,7 +376,7 @@ func (c *Client) Start() (err os.Error) {
 }
 
 // Commit a transaction
-func (c *Client) Commit() (err os.Error) {
+func (c *Client) Commit() (err error) {
 	// Log commit
 	c.log(1, "=== Begin commit ===")
 	// Use commit query
@@ -384,7 +384,7 @@ func (c *Client) Commit() (err os.Error) {
 }
 
 // Rollback a transaction
-func (c *Client) Rollback() (err os.Error) {
+func (c *Client) Rollback() (err error) {
 	// Log rollback
 	c.log(1, "=== Begin rollback ===")
 	// Use rollback query
@@ -412,7 +412,7 @@ func (c *Client) Escape(s string) (esc string) {
 }
 
 // Initialise a new statment
-func (c *Client) InitStmt() (stmt *Statement, err os.Error) {
+func (c *Client) InitStmt() (stmt *Statement, err error) {
 	// Check connection
 	if !c.checkConn() {
 		return nil, &ClientError{CR_COMMANDS_OUT_OF_SYNC, CR_COMMANDS_OUT_OF_SYNC_STR}
@@ -424,7 +424,7 @@ func (c *Client) InitStmt() (stmt *Statement, err os.Error) {
 }
 
 // Initialise and prepare a new statement
-func (c *Client) Prepare(sql string) (stmt *Statement, err os.Error) {
+func (c *Client) Prepare(sql string) (stmt *Statement, err error) {
 	// Initialise a new statement
 	stmt, err = c.InitStmt()
 	if err != nil {
@@ -446,8 +446,8 @@ func (c *Client) reset() {
 }
 
 // Format errors
-func (c *Client) fmtError(str Error, args ...interface{}) Error {
-	return Error(fmt.Sprintf(string(str), args...))
+func (c *Client) fmtError(str Errstr, args ...interface{}) Errstr {
+	return Errstr(fmt.Sprintf(string(str), args...))
 }
 
 // Logging
@@ -530,7 +530,7 @@ func (c *Client) checkResult() bool {
 }
 
 // Check if a network error occurred
-func (c *Client) checkNet(err os.Error) bool {
+func (c *Client) checkNet(err error) bool {
 	if cErr, ok := err.(*ClientError); ok {
 		if cErr.Errno == CR_SERVER_GONE_ERROR || cErr.Errno == CR_SERVER_LOST {
 			return true
@@ -540,7 +540,7 @@ func (c *Client) checkNet(err os.Error) bool {
 }
 
 // Performs the actual connect
-func (c *Client) connect() (err os.Error) {
+func (c *Client) connect() (err error) {
 	// Connect to server
 	err = c.dial()
 	if err != nil {
@@ -582,7 +582,7 @@ func (c *Client) connect() (err os.Error) {
 }
 
 // Connect to server
-func (c *Client) dial() (err os.Error) {
+func (c *Client) dial() (err error) {
 	// Log connect
 	c.log(1, "Connecting to server via %s to %s", c.network, c.raddr)
 	// Connect to server
@@ -597,7 +597,7 @@ func (c *Client) dial() (err os.Error) {
 		}
 		// Log error
 		if cErr, ok := err.(*ClientError); ok {
-			c.log(1, string(cErr.Error))
+			c.log(1, string(cErr.Errstr))
 		}
 		return
 	}
@@ -612,7 +612,7 @@ func (c *Client) dial() (err os.Error) {
 }
 
 // Read initial packet from server
-func (c *Client) init() (err os.Error) {
+func (c *Client) init() (err error) {
 	// Log read packet
 	c.log(1, "Reading handshake initialization packet from server")
 	// Read packet
@@ -653,7 +653,7 @@ func (c *Client) init() (err os.Error) {
 }
 
 // Send auth packet to the server
-func (c *Client) auth() (err os.Error) {
+func (c *Client) auth() (err error) {
 	// Log write packet
 	c.log(1, "Sending authentication packet to server")
 	// Construct packet
@@ -699,7 +699,7 @@ func (c *Client) auth() (err os.Error) {
 }
 
 // Simple non-recovered reconnect
-func (c *Client) simpleReconnect(err os.Error) os.Error {
+func (c *Client) simpleReconnect(err error) error {
 	if err != nil && c.checkNet(err) && c.Reconnect {
 		c.log(1, "!!! Lost connection to server !!!")
 		c.connected = false
@@ -712,7 +712,7 @@ func (c *Client) simpleReconnect(err os.Error) os.Error {
 }
 
 // Perform reconnect if a network error occurs
-func (c *Client) reconnect() (err os.Error) {
+func (c *Client) reconnect() (err error) {
 	// Log auto reconnect
 	c.log(1, "=== Begin auto reconnect attempt ===")
 	// Reset the client
@@ -730,7 +730,7 @@ func (c *Client) reconnect() (err os.Error) {
 }
 
 // Send a command to the server
-func (c *Client) command(command command, args ...interface{}) (err os.Error) {
+func (c *Client) command(command command, args ...interface{}) (err error) {
 	// Log write packet
 	c.log(1, "Sending command packet to server")
 	// Simple validation, arg count
@@ -783,7 +783,7 @@ func (c *Client) command(command command, args ...interface{}) (err os.Error) {
 }
 
 // Get field packets for a result
-func (c *Client) getFields() (err os.Error) {
+func (c *Client) getFields() (err error) {
 	// Check for a valid result
 	if c.result == nil {
 		return &ClientError{CR_NO_RESULT_SET, CR_NO_RESULT_SET_STR}
@@ -791,8 +791,8 @@ func (c *Client) getFields() (err os.Error) {
 	// Read fields till EOF is returned
 	for {
 		c.sequence++
-		eof, err := c.getResult(PACKET_FIELD | PACKET_EOF)
-		if err != nil {
+		eof, _err := c.getResult(PACKET_FIELD | PACKET_EOF)
+		if _err != nil {
 			return
 		}
 		if eof {
@@ -803,7 +803,7 @@ func (c *Client) getFields() (err os.Error) {
 }
 
 // Get next row for a result
-func (c *Client) getRow() (eof bool, err os.Error) {
+func (c *Client) getRow() (eof bool, err error) {
 	// Check for a valid result
 	if c.result == nil {
 		return false, &ClientError{CR_NO_RESULT_SET, CR_NO_RESULT_SET_STR}
@@ -815,10 +815,10 @@ func (c *Client) getRow() (eof bool, err os.Error) {
 }
 
 // Get all rows for the result
-func (c *Client) getAllRows() (err os.Error) {
+func (c *Client) getAllRows() (err error) {
 	for {
-		eof, err := c.getRow()
-		if err != nil {
+		eof, _err := c.getRow()
+		if _err != nil {
 			return
 		}
 		if eof {
@@ -829,7 +829,7 @@ func (c *Client) getAllRows() (err os.Error) {
 }
 
 // Get result
-func (c *Client) getResult(types packetType) (eof bool, err os.Error) {
+func (c *Client) getResult(types packetType) (eof bool, err error) {
 	// Log read result
 	c.log(1, "Reading result packet from server")
 	// Get result packet
@@ -860,7 +860,7 @@ func (c *Client) getResult(types packetType) (eof bool, err os.Error) {
 }
 
 // Sequence check
-func (c *Client) checkSequence(sequence uint8) (err os.Error) {
+func (c *Client) checkSequence(sequence uint8) (err error) {
 	if sequence != c.sequence {
 		c.log(1, "Sequence doesn't match - expected %d but got %d, commands out of sync", c.sequence, sequence)
 		return &ClientError{CR_COMMANDS_OUT_OF_SYNC, CR_COMMANDS_OUT_OF_SYNC_STR}

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -7,8 +7,7 @@ package mysql
 
 import (
 	"fmt"
-	"os"
-	"rand"
+	"math/rand"
 	"strconv"
 	"testing"
 )
@@ -50,7 +49,7 @@ const (
 
 var (
 	db  *Client
-	err os.Error
+	err error
 )
 
 type SimpleRow struct {
@@ -144,14 +143,14 @@ func TestSimple(t *testing.T) {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Create table")
 	err = db.Query(CREATE_SIMPLE)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Insert 1000 records")
 	rowMap := make(map[uint64][]string)
 	for i := 0; i < 1000; i++ {
@@ -164,21 +163,21 @@ func TestSimple(t *testing.T) {
 		row := []string{fmt.Sprintf("%d", num), str1, str2}
 		rowMap[db.LastInsertId] = row
 	}
-	
+
 	t.Logf("Select inserted data")
 	err = db.Query(SELECT_SIMPLE)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Use result")
 	res, err := db.UseResult()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Validate inserted data")
 	for {
 		row, err := res.FetchRow()
@@ -186,20 +185,20 @@ func TestSimple(t *testing.T) {
 			break
 		}
 		id := row[0].(uint64)
-		num, str1, str2 := strconv.Itoa64(row[1].(int64)), row[2].(string), string(row[3].([]byte))
+		num, str1, str2 := strconv.FormatInt(row[1].(int64), 10), row[2].(string), string(row[3].([]byte))
 		if rowMap[id][0] != num || rowMap[id][1] != str1 || rowMap[id][2] != str2 {
 			t.Logf("String from database doesn't match local string")
 			t.Fail()
 		}
 	}
-	
+
 	t.Logf("Free result")
 	err = res.Free()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Update some records")
 	for i := uint64(0); i < 1000; i += 5 {
 		rowMap[i+1][2] = randString(256)
@@ -213,21 +212,21 @@ func TestSimple(t *testing.T) {
 			t.Fail()
 		}
 	}
-	
+
 	t.Logf("Select updated data")
 	err = db.Query(SELECT_SIMPLE)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Store result")
 	res, err = db.StoreResult()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Validate updated data")
 	for {
 		row, err := res.FetchRow()
@@ -235,14 +234,14 @@ func TestSimple(t *testing.T) {
 			break
 		}
 		id := row[0].(uint64)
-		num, str1, str2 := strconv.Itoa64(row[1].(int64)), row[2].(string), string(row[3].([]byte))
+		num, str1, str2 := strconv.FormatInt(row[1].(int64), 10), row[2].(string), string(row[3].([]byte))
 		if rowMap[id][0] != num || rowMap[id][1] != str1 || rowMap[id][2] != str2 {
 			t.Logf("%#v %#v", rowMap[id], row)
 			t.Logf("String from database doesn't match local string")
 			t.Fail()
 		}
 	}
-	
+
 	t.Logf("Free result")
 	err = res.Free()
 	if err != nil {
@@ -256,7 +255,7 @@ func TestSimple(t *testing.T) {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Close connection")
 	err = db.Close()
 	if err != nil {
@@ -273,35 +272,35 @@ func TestSimpleStatement(t *testing.T) {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Init statement")
 	stmt, err := db.InitStmt()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Prepare create table")
 	err = stmt.Prepare(CREATE_SIMPLE)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Execute create table")
 	err = stmt.Execute()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Prepare insert")
 	err = stmt.Prepare(INSERT_SIMPLE_STMT)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Insert 1000 records")
 	rowMap := make(map[uint64][]string)
 	for i := 0; i < 1000; i++ {
@@ -319,25 +318,25 @@ func TestSimpleStatement(t *testing.T) {
 		row := []string{fmt.Sprintf("%d", num), str1, str2}
 		rowMap[stmt.LastInsertId] = row
 	}
-	
+
 	t.Logf("Prepare select")
 	err = stmt.Prepare(SELECT_SIMPLE)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Execute select")
 	err = stmt.Execute()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Bind result")
 	row := SimpleRow{}
 	stmt.BindResult(&row.Id, &row.Number, &row.String, &row.Text, &row.Date)
-	
+
 	t.Logf("Validate inserted data")
 	for {
 		eof, err := stmt.Fetch()
@@ -353,21 +352,21 @@ func TestSimpleStatement(t *testing.T) {
 			t.Fail()
 		}
 	}
-	
+
 	t.Logf("Reset statement")
 	err = stmt.Reset()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Prepare update")
 	err = stmt.Prepare(UPDATE_SIMPLE_STMT)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Update some records")
 	for i := uint64(0); i < 1000; i += 5 {
 		rowMap[i+1][2] = randString(256)
@@ -382,21 +381,21 @@ func TestSimpleStatement(t *testing.T) {
 			t.Fail()
 		}
 	}
-	
+
 	t.Logf("Prepare select updated")
 	err = stmt.Prepare(SELECT_SIMPLE)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Execute select updated")
 	err = stmt.Execute()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Validate updated data")
 	for {
 		eof, err := stmt.Fetch()
@@ -412,35 +411,35 @@ func TestSimpleStatement(t *testing.T) {
 			t.Fail()
 		}
 	}
-	
+
 	t.Logf("Free result")
 	err = stmt.FreeResult()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Prepare drop")
 	err = stmt.Prepare(DROP_SIMPLE)
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Execute drop")
 	err = stmt.Execute()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Close statement")
 	err = stmt.Close()
 	if err != nil {
 		t.Logf("Error %s", err)
 		t.Fail()
 	}
-	
+
 	t.Logf("Close connection")
 	err = db.Close()
 	if err != nil {

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -181,8 +181,8 @@ func TestSimple(t *testing.T) {
 	
 	t.Logf("Validate inserted data")
 	for {
-		row := res.FetchRow()
-		if row == nil {
+		row, err := res.FetchRow()
+		if row == nil || err != nil {
 			break
 		}
 		id := row[0].(uint64)
@@ -230,8 +230,8 @@ func TestSimple(t *testing.T) {
 	
 	t.Logf("Validate updated data")
 	for {
-		row := res.FetchRow()
-		if row == nil {
+		row, err := res.FetchRow()
+		if row == nil || err != nil {
 			break
 		}
 		id := row[0].(uint64)

--- a/packet.go
+++ b/packet.go
@@ -7,7 +7,7 @@ package mysql
 
 import (
 	"bytes"
-	"os"
+	"io"
 )
 
 // Packet type identifier
@@ -33,12 +33,12 @@ const (
 
 // Readable packet interface
 type packetReadable interface {
-	read(data []byte) (err os.Error)
+	read(data []byte) (err error)
 }
 
 // Writable packet interface
 type packetWritable interface {
-	write() (data []byte, err os.Error)
+	write() (data []byte, err error)
 }
 
 // Generic packet interface (read/writable)
@@ -54,19 +54,19 @@ type packetBase struct {
 }
 
 // Read a slice from the data
-func (p *packetBase) readSlice(data []byte, delim byte) (slice []byte, err os.Error) {
+func (p *packetBase) readSlice(data []byte, delim byte) (slice []byte, err error) {
 	pos := bytes.IndexByte(data, delim)
 	if pos > -1 {
 		slice = data[:pos]
 	} else {
 		slice = data
-		err = os.EOF
+		err = io.EOF
 	}
 	return
 }
 
 // Read length coded string
-func (p *packetBase) readLengthCodedString(data []byte) (s string, n int, err os.Error) {
+func (p *packetBase) readLengthCodedString(data []byte) (s string, n int, err error) {
 	// Read bytes and convert to string
 	b, n, err := p.readLengthCodedBytes(data)
 	if err != nil {
@@ -76,7 +76,7 @@ func (p *packetBase) readLengthCodedString(data []byte) (s string, n int, err os
 	return
 }
 
-func (p *packetBase) readLengthCodedBytes(data []byte) (b []byte, n int, err os.Error) {
+func (p *packetBase) readLengthCodedBytes(data []byte) (b []byte, n int, err error) {
 	// Get string length
 	num, n, err := btolcb(data)
 	if err != nil {
@@ -84,7 +84,7 @@ func (p *packetBase) readLengthCodedBytes(data []byte) (b []byte, n int, err os.
 	}
 	// Check data length
 	if len(data) < n+int(num) {
-		err = os.EOF
+		err = io.EOF
 		return
 	}
 	// Get bytes
@@ -101,7 +101,6 @@ func (p *packetBase) addHeader(data []byte) (pkt []byte) {
 	return
 }
 
-
 // Init packet
 type packetInit struct {
 	packetBase
@@ -115,7 +114,7 @@ type packetInit struct {
 }
 
 // Init packet reader
-func (p *packetInit) read(data []byte) (err os.Error) {
+func (p *packetInit) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -169,7 +168,7 @@ type packetAuth struct {
 }
 
 // Auth packet writer
-func (p *packetAuth) write() (data []byte, err os.Error) {
+func (p *packetAuth) write() (data []byte, err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -238,7 +237,7 @@ type packetOK struct {
 }
 
 // OK packet reader
-func (p *packetOK) read(data []byte) (err os.Error) {
+func (p *packetOK) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -285,7 +284,7 @@ type packetError struct {
 }
 
 // Error packet reader
-func (p *packetError) read(data []byte) (err os.Error) {
+func (p *packetError) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -318,7 +317,7 @@ type packetEOF struct {
 }
 
 // EOF packet reader
-func (p *packetEOF) read(data []byte) (err os.Error) {
+func (p *packetEOF) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -347,7 +346,7 @@ type packetPassword struct {
 }
 
 // Password packet writer
-func (p *packetPassword) write() (data []byte, err os.Error) {
+func (p *packetPassword) write() (data []byte, err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -371,7 +370,7 @@ type packetCommand struct {
 }
 
 // Command packet writer
-func (p *packetCommand) write() (data []byte, err os.Error) {
+func (p *packetCommand) write() (data []byte, err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -450,7 +449,7 @@ type packetResultSet struct {
 }
 
 // Result set packet reader
-func (p *packetResultSet) read(data []byte) (err os.Error) {
+func (p *packetResultSet) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -493,7 +492,7 @@ type packetField struct {
 }
 
 // Field packet reader
-func (p *packetField) read(data []byte) (err os.Error) {
+func (p *packetField) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -599,7 +598,7 @@ type packetRowData struct {
 }
 
 // Row data packet reader
-func (p *packetRowData) read(data []byte) (err os.Error) {
+func (p *packetRowData) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -611,8 +610,8 @@ func (p *packetRowData) read(data []byte) (err os.Error) {
 	// Loop until end of packet
 	for {
 		// Read string
-		b, n, err := p.readLengthCodedBytes(data[pos:])
-		if err != nil {
+		b, n, _err := p.readLengthCodedBytes(data[pos:])
+		if _err != nil {
 			return
 		}
 		// Add to slice
@@ -636,7 +635,7 @@ type packetPrepareOK struct {
 }
 
 // Prepare ok packet reader
-func (p *packetPrepareOK) read(data []byte) (err os.Error) {
+func (p *packetPrepareOK) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -669,7 +668,7 @@ type packetParameter struct {
 }
 
 // Parameter packet reader
-func (p *packetParameter) read(data []byte) (err os.Error) {
+func (p *packetParameter) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -690,7 +689,7 @@ type packetLongData struct {
 }
 
 // Long data packet writer
-func (p *packetLongData) write() (data []byte, err os.Error) {
+func (p *packetLongData) write() (data []byte, err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -724,7 +723,7 @@ type packetExecute struct {
 }
 
 // Execute packet writer
-func (p *packetExecute) write() (data []byte, err os.Error) {
+func (p *packetExecute) write() (data []byte, err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {
@@ -769,7 +768,7 @@ type packetRowBinary struct {
 }
 
 // Row binary packet reader
-func (p *packetRowBinary) read(data []byte) (err os.Error) {
+func (p *packetRowBinary) read(data []byte) (err error) {
 	// Recover errors
 	defer func() {
 		if e := recover(); e != nil {

--- a/password.go
+++ b/password.go
@@ -92,17 +92,17 @@ func scramble41(message, password []byte) (result []byte) {
 	// SHA1 encode
 	crypt := sha1.New()
 	crypt.Write(password)
-	stg1Hash := crypt.Sum()
+	stg1Hash := crypt.Sum(nil)
 	// token = SHA1(SHA1(stage1_hash), scramble) XOR stage1_hash
 	// SHA1 encode again
 	crypt.Reset()
 	crypt.Write(stg1Hash)
-	stg2Hash := crypt.Sum()
+	stg2Hash := crypt.Sum(nil)
 	// SHA1 2nd hash and scramble
 	crypt.Reset()
 	crypt.Write(message)
 	crypt.Write(stg2Hash)
-	stg3Hash := crypt.Sum()
+	stg3Hash := crypt.Sum(nil)
 	// XOR with first hash
 	result = make([]byte, 20)
 	for i := range result {

--- a/reader.go
+++ b/reader.go
@@ -8,7 +8,6 @@ package mysql
 import (
 	"io"
 	"net"
-	"os"
 )
 
 // Packet reader struct
@@ -26,12 +25,12 @@ func newReader(conn io.ReadWriteCloser) *reader {
 }
 
 // Read the next packet
-func (r *reader) readPacket(types packetType) (p packetReadable, err os.Error) {
+func (r *reader) readPacket(types packetType) (p packetReadable, err error) {
 	// Deferred error processing
 	defer func() {
 		if err != nil {
 			// EOF errors
-			if err == os.EOF || err == io.ErrUnexpectedEOF {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				err = &ClientError{CR_SERVER_LOST, CR_SERVER_LOST_STR}
 			}
 			// OpError
@@ -127,7 +126,7 @@ func (r *reader) readPacket(types packetType) (p packetReadable, err os.Error) {
 }
 
 // Read n bytes long number
-func (r *reader) readNumber(n uint8) (num uint64, err os.Error) {
+func (r *reader) readNumber(n uint8) (num uint64, err error) {
 	// Read bytes into array
 	buf := make([]byte, n)
 	nr, err := io.ReadFull(r.conn, buf)

--- a/result.go
+++ b/result.go
@@ -5,8 +5,6 @@
 // license that can be found in the LICENSE file.
 package mysql
 
-import "os"
-
 // Result struct
 type Result struct {
 	// Pointer to the client
@@ -72,7 +70,7 @@ func (r *Result) RowCount() uint64 {
 }
 
 // Fetch a row
-func (r *Result) FetchRow() (row Row, e os.Error) {
+func (r *Result) FetchRow() (row Row, e error) {
 	// Stored result
 	if r.mode == RESULT_STORED {
 		// Check if all rows have been fetched
@@ -98,7 +96,7 @@ func (r *Result) FetchRow() (row Row, e os.Error) {
 }
 
 // Fetch a map
-func (r *Result) FetchMap() (m Map, err os.Error) {
+func (r *Result) FetchMap() (m Map, err error) {
 	// Fetch row
 	row, err := r.FetchRow()
 	if row != nil {
@@ -122,7 +120,7 @@ func (r *Result) FetchRows() []Row {
 }
 
 // Free the result
-func (r *Result) Free() (err os.Error) {
+func (r *Result) Free() (err error) {
 	err = r.c.FreeResult()
 	return
 }

--- a/result.go
+++ b/result.go
@@ -72,45 +72,45 @@ func (r *Result) RowCount() uint64 {
 }
 
 // Fetch a row
-func (r *Result) FetchRow() Row {
+func (r *Result) FetchRow() (row Row, e os.Error) {
 	// Stored result
 	if r.mode == RESULT_STORED {
 		// Check if all rows have been fetched
 		if r.rowPos < uint64(len(r.rows)) {
 			// Increment position and return current row
 			r.rowPos++
-			return r.rows[r.rowPos-1]
+			row = r.rows[r.rowPos-1]
 		}
 	}
 	// Used result
 	if r.mode == RESULT_USED {
 		if r.allRead == false {
 			eof, err := r.c.getRow()
-			if err != nil {
-				return nil
-			}
+			e = err
 			if eof {
 				r.allRead = true
 			} else {
-				return r.rows[0]
+				row = r.rows[0]
 			}
 		}
 	}
-	return nil
+	return
 }
 
 // Fetch a map
-func (r *Result) FetchMap() Map {
+func (r *Result) FetchMap() (m Map, err os.Error) {
 	// Fetch row
-	row := r.FetchRow()
+	row, err := r.FetchRow()
 	if row != nil {
 		rowMap := make(Map)
 		for key, val := range row {
 			rowMap[r.fields[key].Name] = val
 		}
-		return rowMap
+		m = rowMap
+	} else {
+		m = nil
 	}
-	return nil
+	return
 }
 
 // Fetch all rows

--- a/statement.go
+++ b/statement.go
@@ -6,7 +6,6 @@
 package mysql
 
 import (
-	"os"
 	"reflect"
 	"strconv"
 )
@@ -42,7 +41,7 @@ type Statement struct {
 }
 
 // Prepare new statement
-func (s *Statement) Prepare(sql string) (err os.Error) {
+func (s *Statement) Prepare(sql string) (err error) {
 	// Auto reconnect
 	defer func() {
 		if err != nil && s.c.checkNet(err) && s.c.Reconnect {
@@ -77,8 +76,8 @@ func (s *Statement) Prepare(sql string) (err os.Error) {
 	if s.paramCount > 0 {
 		for {
 			s.c.sequence++
-			eof, err := s.getResult(PACKET_PARAM | PACKET_EOF)
-			if err != nil {
+			eof, _err := s.getResult(PACKET_PARAM | PACKET_EOF)
+			if _err != nil {
 				return
 			}
 			if eof {
@@ -105,7 +104,7 @@ func (s *Statement) ParamCount() uint16 {
 }
 
 // Bind params
-func (s *Statement) BindParams(params ...interface{}) (err os.Error) {
+func (s *Statement) BindParams(params ...interface{}) (err error) {
 	// Check prepared
 	if !s.prepared {
 		return &ClientError{CR_NO_PREPARE_STMT, CR_NO_PREPARE_STMT_STR}
@@ -208,7 +207,7 @@ func (s *Statement) BindParams(params ...interface{}) (err os.Error) {
 }
 
 // Send long data
-func (s *Statement) SendLongData(num int, data []byte) (err os.Error) {
+func (s *Statement) SendLongData(num int, data []byte) (err error) {
 	// Auto reconnect
 	defer func() {
 		err = s.c.simpleReconnect(err)
@@ -264,7 +263,7 @@ func (s *Statement) SendLongData(num int, data []byte) (err os.Error) {
 }
 
 // Execute
-func (s *Statement) Execute() (err os.Error) {
+func (s *Statement) Execute() (err error) {
 	// Auto reconnect
 	defer func() {
 		if err != nil && s.c.checkNet(err) && s.c.Reconnect {
@@ -362,7 +361,7 @@ func (s *Statement) FetchColumns() []*Field {
 }
 
 // Bind result
-func (s *Statement) BindResult(params ...interface{}) (err os.Error) {
+func (s *Statement) BindResult(params ...interface{}) (err error) {
 	s.resultParams = params
 	return
 }
@@ -377,7 +376,7 @@ func (s *Statement) RowCount() uint64 {
 }
 
 // Fetch next row 
-func (s *Statement) Fetch() (eof bool, err os.Error) {
+func (s *Statement) Fetch() (eof bool, err error) {
 	// Auto reconnect
 	defer func() {
 		err = s.c.simpleReconnect(err)
@@ -473,7 +472,7 @@ func (s *Statement) Fetch() (eof bool, err os.Error) {
 }
 
 // Store result
-func (s *Statement) StoreResult() (err os.Error) {
+func (s *Statement) StoreResult() (err error) {
 	// Auto reconnect
 	defer func() {
 		err = s.c.simpleReconnect(err)
@@ -500,7 +499,7 @@ func (s *Statement) StoreResult() (err os.Error) {
 }
 
 // Free result
-func (s *Statement) FreeResult() (err os.Error) {
+func (s *Statement) FreeResult() (err error) {
 	// Auto reconnect
 	defer func() {
 		err = s.c.simpleReconnect(err)
@@ -526,7 +525,7 @@ func (s *Statement) MoreResults() bool {
 }
 
 // Next result
-func (s *Statement) NextResult() (more bool, err os.Error) {
+func (s *Statement) NextResult() (more bool, err error) {
 	// Auto reconnect
 	defer func() {
 		err = s.c.simpleReconnect(err)
@@ -558,7 +557,7 @@ func (s *Statement) NextResult() (more bool, err os.Error) {
 }
 
 // Reset statement
-func (s *Statement) Reset() (err os.Error) {
+func (s *Statement) Reset() (err error) {
 	// Auto reconnect
 	defer func() {
 		err = s.c.simpleReconnect(err)
@@ -591,7 +590,7 @@ func (s *Statement) Reset() (err os.Error) {
 }
 
 // Close statement
-func (s *Statement) Close() (err os.Error) {
+func (s *Statement) Close() (err error) {
 	// Auto reconnect
 	defer func() {
 		err = s.c.simpleReconnect(err)
@@ -648,12 +647,12 @@ func (s *Statement) getNullBitMap() (nbm []byte) {
 }
 
 // Get all result fields
-func (s *Statement) getFields() (err os.Error) {
+func (s *Statement) getFields() (err error) {
 	// Loop till EOF
 	for {
 		s.c.sequence++
-		eof, err := s.getResult(PACKET_FIELD | PACKET_EOF)
-		if err != nil {
+		eof, _err := s.getResult(PACKET_FIELD | PACKET_EOF)
+		if _err != nil {
 			return
 		}
 		if eof {
@@ -664,7 +663,7 @@ func (s *Statement) getFields() (err os.Error) {
 }
 
 // Get next row for a result
-func (s *Statement) getRow() (eof bool, err os.Error) {
+func (s *Statement) getRow() (eof bool, err error) {
 	// Check for a valid result
 	if s.result == nil {
 		return false, &ClientError{CR_NO_RESULT_SET, CR_NO_RESULT_SET_STR}
@@ -676,10 +675,10 @@ func (s *Statement) getRow() (eof bool, err os.Error) {
 }
 
 // Get all rows for the result
-func (s *Statement) getAllRows() (err os.Error) {
+func (s *Statement) getAllRows() (err error) {
 	for {
-		eof, err := s.getRow()
-		if err != nil {
+		eof, _err := s.getRow()
+		if _err != nil {
 			return
 		}
 		if eof {
@@ -690,7 +689,7 @@ func (s *Statement) getAllRows() (err os.Error) {
 }
 
 // Get result
-func (s *Statement) getResult(types packetType) (eof bool, err os.Error) {
+func (s *Statement) getResult(types packetType) (eof bool, err error) {
 	// Log read result
 	s.c.log(1, "Reading result packet from server")
 	// Get result packet
@@ -725,7 +724,7 @@ func (s *Statement) getResult(types packetType) (eof bool, err os.Error) {
 }
 
 // Free any result sets waiting to be read
-func (s *Statement) freeAll(next bool) (err os.Error) {
+func (s *Statement) freeAll(next bool) (err error) {
 	// Check for unread rows
 	if !s.result.allRead {
 		// Read all rows

--- a/writer.go
+++ b/writer.go
@@ -8,7 +8,6 @@ package mysql
 import (
 	"io"
 	"net"
-	"os"
 )
 
 // Packet writer struct
@@ -24,12 +23,12 @@ func newWriter(conn io.ReadWriteCloser) *writer {
 }
 
 // Write packet to the server
-func (w *writer) writePacket(p packetWritable) (err os.Error) {
+func (w *writer) writePacket(p packetWritable) (err error) {
 	// Deferred error processing
 	defer func() {
 		if err != nil {
 			// EOF errors
-			if err == os.EOF || err == io.ErrUnexpectedEOF {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				err = &ClientError{CR_SERVER_LOST, CR_SERVER_LOST_STR}
 			}
 			// OpError


### PR DESCRIPTION
I had a hard time debugging a sudden end of data, this patch hacks up
the library to get the errors where I could see them.

This isn't so much of a problem with stored results, but when using
results, it was possible to get disconnected by the server and have it
be entirely indistinguishable from just reaching the end of the table.

This patch adds os.Error return values to FetchMap and FetchRow, which
allow the user to see any errors thus encountered.

I attempted to make tests work with the changes, but didn't feel like
mucking with my sandbox DB to actually run them.

Feel absolutely free to solve this problem in a different way, but this way
worked for me so I figured I could at least send the code along.
